### PR TITLE
feat: Add paging/search options to group "child group" and "user" listings

### DIFF
--- a/bundle-es2015/models/GroupListOptions.d.ts
+++ b/bundle-es2015/models/GroupListOptions.d.ts
@@ -1,3 +1,5 @@
 import { UserListOptions } from './UserListOptions';
 export interface GroupListOptions extends UserListOptions {
 }
+export declare type GroupChildListOptions = Pick<GroupListOptions, Exclude<keyof GroupListOptions, 'q'>>;
+export declare type GroupUserListOptions = Pick<UserListOptions, Exclude<keyof UserListOptions, 'q'>>;

--- a/bundle-es2015/models/IGroupOperations.d.ts
+++ b/bundle-es2015/models/IGroupOperations.d.ts
@@ -2,6 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
+import { UserListOptions } from '.';
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
     getByName(groupName: string): Promise<Group>;
@@ -15,8 +16,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
 }

--- a/bundle-es2015/models/IGroupOperations.d.ts
+++ b/bundle-es2015/models/IGroupOperations.d.ts
@@ -2,7 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
-import { UserListOptions } from '.';
+import { GroupUserListOptions, GroupChildListOptions } from '.';
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
     getByName(groupName: string): Promise<Group>;
@@ -16,8 +16,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
 }

--- a/bundle-es2015/security/groups/group-operations.d.ts
+++ b/bundle-es2015/security/groups/group-operations.d.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
 import { IHttpClient, PagedList } from 'contensis-core-api';
 export declare class GroupOperations implements IGroupOperations {
     private httpClient;
@@ -16,10 +16,10 @@ export declare class GroupOperations implements IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
     private getGroup;
     private getUsersInGroup;
     private getChildGroups;

--- a/bundle-es2015/security/groups/group-operations.d.ts
+++ b/bundle-es2015/security/groups/group-operations.d.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, GroupUserListOptions, GroupChildListOptions } from '../../models';
 import { IHttpClient, PagedList } from 'contensis-core-api';
 export declare class GroupOperations implements IGroupOperations {
     private httpClient;
@@ -16,10 +16,10 @@ export declare class GroupOperations implements IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
     private getGroup;
     private getUsersInGroup;
     private getChildGroups;

--- a/bundle-es2015/security/groups/group-operations.js
+++ b/bundle-es2015/security/groups/group-operations.js
@@ -4,6 +4,11 @@ let listMappers = {
     pageSize: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageSize) || (params.pageSize),
     order: (value) => (value && value.length > 0) ? value : null,
 };
+let userListMappers = {
+    pageIndex: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageIndex) || (params.pageIndex),
+    pageSize: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageSize) || (params.pageSize),
+    order: (value) => (value && value.length > 0) ? value : null,
+};
 export class GroupOperations {
     constructor(httpClient, contensisClient) {
         this.httpClient = httpClient;
@@ -199,29 +204,29 @@ export class GroupOperations {
             });
         });
     }
-    getUsersByGroupId(groupId) {
+    getUsersByGroupId(groupId, options) {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
-        return this.getUsersInGroup(groupId);
+        return this.getUsersInGroup(groupId, options);
     }
-    getUsersByGroupName(groupName) {
+    getUsersByGroupName(groupName, options) {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
-        return this.getUsersInGroup(groupName);
+        return this.getUsersInGroup(groupName, options);
     }
-    getChildGroupsByGroupId(groupId) {
+    getChildGroupsByGroupId(groupId, options) {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
-        return this.getChildGroups(groupId);
+        return this.getChildGroups(groupId, options);
     }
-    getChildGroupsByGroupName(groupName) {
+    getChildGroupsByGroupName(groupName, options) {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
-        return this.getChildGroups(groupName);
+        return this.getChildGroups(groupName, options);
     }
     getGroup(idOrName) {
         let url = UrlBuilder.create('/api/security/groups/:idOrName', {})
@@ -234,10 +239,12 @@ export class GroupOperations {
             });
         });
     }
-    getUsersInGroup(idOrName) {
-        let url = UrlBuilder.create('/api/security/groups/:idOrName/users', {})
+    getUsersInGroup(idOrName, options) {
+        let url = UrlBuilder.create('/api/security/groups/:idOrName/users', !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(userListMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request(url, {
@@ -245,10 +252,12 @@ export class GroupOperations {
             });
         });
     }
-    getChildGroups(idOrName) {
-        let url = UrlBuilder.create('/api/security/groups/:idOrName/groups', {})
+    getChildGroups(idOrName, options) {
+        let url = UrlBuilder.create('/api/security/groups/:idOrName/groups', !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(listMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request(url, {

--- a/bundle-es2015/security/groups/group-operations.spec.js
+++ b/bundle-es2015/security/groups/group-operations.spec.js
@@ -325,12 +325,42 @@ describe('Group Operations', () => {
             expect(users.items.length).toEqual(2);
             expect(users.items[1].username).toEqual(defaultUsers[1].username);
         });
+        it('by group id with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupId(defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].id}/users?order=username&pageIndex=1&pageSize=50`,
+                getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(defaultUsers[1].username);
+        });
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(getDefaultConfig());
             let users = await client.security.groups.getUsersByGroupName(defaultGroups[0].name);
             expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
             expect(global.fetch.calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${defaultGroups[0].name}/users`,
+                getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(defaultUsers[1].username);
+        });
+        it('by group name with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupName(defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].name}/users?order=username&pageIndex=1&pageSize=50`,
                 getDefaultFetchRequest()
             ]);
             expect(users).not.toBeNull();
@@ -363,12 +393,42 @@ describe('Group Operations', () => {
             expect(groups.items.length).toEqual(2);
             expect(groups.items[1].name).toEqual(defaultGroups[1].name);
         });
+        it('by group id with options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let groups = await client.security.groups.getChildGroupsByGroupId(defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].id}/groups?order=name&pageIndex=1&pageSize=50`,
+                getDefaultFetchRequest()
+            ]);
+            expect(groups).not.toBeNull();
+            expect(groups.items.length).toEqual(2);
+            expect(groups.items[1].name).toEqual(defaultGroups[1].name);
+        });
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(getDefaultConfig());
             let users = await client.security.groups.getChildGroupsByGroupName(defaultGroups[0].name);
             expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
             expect(global.fetch.calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${defaultGroups[0].name}/groups`,
+                getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].name).toEqual(defaultGroups[1].name);
+        });
+        it('by group name with options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getChildGroupsByGroupName(defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].name}/groups?order=name&pageIndex=1&pageSize=50`,
                 getDefaultFetchRequest()
             ]);
             expect(users).not.toBeNull();

--- a/lib/models/GroupListOptions.d.ts
+++ b/lib/models/GroupListOptions.d.ts
@@ -1,3 +1,5 @@
 import { UserListOptions } from './UserListOptions';
 export interface GroupListOptions extends UserListOptions {
 }
+export declare type GroupChildListOptions = Pick<GroupListOptions, Exclude<keyof GroupListOptions, 'q'>>;
+export declare type GroupUserListOptions = Pick<UserListOptions, Exclude<keyof UserListOptions, 'q'>>;

--- a/lib/models/IGroupOperations.d.ts
+++ b/lib/models/IGroupOperations.d.ts
@@ -2,6 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
+import { UserListOptions } from '.';
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
     getByName(groupName: string): Promise<Group>;
@@ -15,8 +16,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
 }

--- a/lib/models/IGroupOperations.d.ts
+++ b/lib/models/IGroupOperations.d.ts
@@ -2,7 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
-import { UserListOptions } from '.';
+import { GroupUserListOptions, GroupChildListOptions } from '.';
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
     getByName(groupName: string): Promise<Group>;
@@ -16,8 +16,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
 }

--- a/lib/security/groups/group-operations.d.ts
+++ b/lib/security/groups/group-operations.d.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
 import { IHttpClient, PagedList } from 'contensis-core-api';
 export declare class GroupOperations implements IGroupOperations {
     private httpClient;
@@ -16,10 +16,10 @@ export declare class GroupOperations implements IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
     private getGroup;
     private getUsersInGroup;
     private getChildGroups;

--- a/lib/security/groups/group-operations.d.ts
+++ b/lib/security/groups/group-operations.d.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, GroupUserListOptions, GroupChildListOptions } from '../../models';
 import { IHttpClient, PagedList } from 'contensis-core-api';
 export declare class GroupOperations implements IGroupOperations {
     private httpClient;
@@ -16,10 +16,10 @@ export declare class GroupOperations implements IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
     private getGroup;
     private getUsersInGroup;
     private getChildGroups;

--- a/lib/security/groups/group-operations.js
+++ b/lib/security/groups/group-operations.js
@@ -6,6 +6,11 @@ let listMappers = {
     pageSize: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageSize) || (params.pageSize),
     order: (value) => (value && value.length > 0) ? value : null,
 };
+let userListMappers = {
+    pageIndex: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageIndex) || (params.pageIndex),
+    pageSize: (value, options, params) => (options && options.pageOptions && options.pageOptions.pageSize) || (params.pageSize),
+    order: (value) => (value && value.length > 0) ? value : null,
+};
 class GroupOperations {
     constructor(httpClient, contensisClient) {
         this.httpClient = httpClient;
@@ -201,29 +206,29 @@ class GroupOperations {
             });
         });
     }
-    getUsersByGroupId(groupId) {
+    getUsersByGroupId(groupId, options) {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
-        return this.getUsersInGroup(groupId);
+        return this.getUsersInGroup(groupId, options);
     }
-    getUsersByGroupName(groupName) {
+    getUsersByGroupName(groupName, options) {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
-        return this.getUsersInGroup(groupName);
+        return this.getUsersInGroup(groupName, options);
     }
-    getChildGroupsByGroupId(groupId) {
+    getChildGroupsByGroupId(groupId, options) {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
-        return this.getChildGroups(groupId);
+        return this.getChildGroups(groupId, options);
     }
-    getChildGroupsByGroupName(groupName) {
+    getChildGroupsByGroupName(groupName, options) {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
-        return this.getChildGroups(groupName);
+        return this.getChildGroups(groupName, options);
     }
     getGroup(idOrName) {
         let url = contensis_core_api_1.UrlBuilder.create('/api/security/groups/:idOrName', {})
@@ -236,10 +241,12 @@ class GroupOperations {
             });
         });
     }
-    getUsersInGroup(idOrName) {
-        let url = contensis_core_api_1.UrlBuilder.create('/api/security/groups/:idOrName/users', {})
+    getUsersInGroup(idOrName, options) {
+        let url = contensis_core_api_1.UrlBuilder.create('/api/security/groups/:idOrName/users', !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(userListMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request(url, {
@@ -247,10 +254,12 @@ class GroupOperations {
             });
         });
     }
-    getChildGroups(idOrName) {
-        let url = contensis_core_api_1.UrlBuilder.create('/api/security/groups/:idOrName/groups', {})
+    getChildGroups(idOrName, options) {
+        let url = contensis_core_api_1.UrlBuilder.create('/api/security/groups/:idOrName/groups', !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(listMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request(url, {

--- a/lib/security/groups/group-operations.spec.js
+++ b/lib/security/groups/group-operations.spec.js
@@ -327,12 +327,42 @@ describe('Group Operations', () => {
             expect(users.items.length).toEqual(2);
             expect(users.items[1].username).toEqual(specs_utils_spec_1.defaultUsers[1].username);
         });
+        it('by group id with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupId(specs_utils_spec_1.defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].id}/users?order=username&pageIndex=1&pageSize=50`,
+                specs_utils_spec_1.getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(specs_utils_spec_1.defaultUsers[1].username);
+        });
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
             let users = await client.security.groups.getUsersByGroupName(specs_utils_spec_1.defaultGroups[0].name);
             expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
             expect(global.fetch.calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].name}/users`,
+                specs_utils_spec_1.getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(specs_utils_spec_1.defaultUsers[1].username);
+        });
+        it('by group name with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupName(specs_utils_spec_1.defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].name}/users?order=username&pageIndex=1&pageSize=50`,
                 specs_utils_spec_1.getDefaultFetchRequest()
             ]);
             expect(users).not.toBeNull();
@@ -365,12 +395,42 @@ describe('Group Operations', () => {
             expect(groups.items.length).toEqual(2);
             expect(groups.items[1].name).toEqual(specs_utils_spec_1.defaultGroups[1].name);
         });
+        it('by group id with options', async () => {
+            let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
+            let groups = await client.security.groups.getChildGroupsByGroupId(specs_utils_spec_1.defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].id}/groups?order=name&pageIndex=1&pageSize=50`,
+                specs_utils_spec_1.getDefaultFetchRequest()
+            ]);
+            expect(groups).not.toBeNull();
+            expect(groups.items.length).toEqual(2);
+            expect(groups.items[1].name).toEqual(specs_utils_spec_1.defaultGroups[1].name);
+        });
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
             let users = await client.security.groups.getChildGroupsByGroupName(specs_utils_spec_1.defaultGroups[0].name);
             expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
             expect(global.fetch.calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].name}/groups`,
+                specs_utils_spec_1.getDefaultFetchRequest()
+            ]);
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].name).toEqual(specs_utils_spec_1.defaultGroups[1].name);
+        });
+        it('by group name with options', async () => {
+            let client = Zengenti.Contensis.Client.create(specs_utils_spec_1.getDefaultConfig());
+            let users = await client.security.groups.getChildGroupsByGroupName(specs_utils_spec_1.defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+            expect(global.fetch.calls.first().args[0]).toEqual(specs_utils_spec_1.getDefaultAuthenticateUrl());
+            expect(global.fetch.calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${specs_utils_spec_1.defaultGroups[0].name}/groups?order=name&pageIndex=1&pageSize=50`,
                 specs_utils_spec_1.getDefaultFetchRequest()
             ]);
             expect(users).not.toBeNull();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contensis-management-api",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -581,7 +581,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -1211,6 +1212,8 @@
     },
     "contensis-core-api": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/contensis-core-api/-/contensis-core-api-1.0.4.tgz",
+      "integrity": "sha512-HG6ocZuTZUozrrSKVSoCUdna+AP86F4vHRXYljXYejKRJ6ItoeguXL8vCKMC5Dz0ZLXnjdN8wTKm9Kz8lk346g==",
       "requires": {
         "@types/detect-node": "^2.0.0",
         "detect-node": "^2.0.4",
@@ -3613,7 +3616,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -5183,7 +5187,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
@@ -7124,7 +7129,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-    "name": "contensis-management-api",
-    "version": "2.0.3",
-    "description": "Contensis Javascript Management API",
-    "engines": {
-        "node": ">=8"
-    },
-    "main": "./lib/index.js",
-    "types": "./lib/index.d.ts",
-    "scripts": {
-        "lint": "npx tslint src/**/*.ts",
-        "pretest": "rimraf coverage/*",
-        "build": "rimraf lib/* && npx tsc -p src/tsconfig-npm.json && npm run lint",
-        "test": "karma start --test-target npm",
-        "test:watch": "karma start --test-target npm --auto-watch --no-single-run",
-        "build:es5": "rimraf bundle-es5/* && npx tsc -p src",
-        "build:esnext": "rimraf bundle-es2015/* && npx tsc -p src/tsconfig-esnext.json && npm run lint",
-        "test:esnext": "karma start",
-        "all": "npm run build && npm run test && npm run build:esnext && npm run test:esnext"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/contensis/contensis-management-api.git"
-    },
-    "author": "Zengenti Ltd <development@zengenti.com>",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/contensis/contensis-management-api/issues"
-    },
-    "homepage": "https://github.com/contensis/contensis-management-api#readme",
-    "devDependencies": {
-        "@types/jasmine": "^3.5.14",
-        "@types/node": "^12.12.54",
-        "copy-webpack-plugin": "^6.4.0",
-        "istanbul-instrumenter-loader": "^3.0.1",
-        "jasmine-ajax": "^4.0.0",
-        "jasmine-core": "^3.6.0",
-        "karma": "^6.1.1",
-        "karma-chrome-launcher": "^2.2.0",
-        "karma-coverage": "^1.1.2",
-        "karma-jasmine": "^2.0.1",
-        "karma-jasmine-html-reporter": "^1.5.4",
-        "karma-mocha-reporter": "^2.2.5",
-        "karma-sourcemap-loader": "^0.3.8",
-        "karma-webpack": "^3.0.5",
-        "rimraf": "^2.7.1",
-        "ts-loader": "^3.5.0",
-        "tslint": "^5.20.1",
-        "typescript": "3.3.1",
-        "uglify-js": "^3.10.3",
-        "webpack": "3.12.0"
-    },
-    "dependencies": {
-        "@types/graceful-fs": "^4.1.3",
-        "contensis-core-api": "1.0.4",
-        "cross-fetch": "^3.0.6",
-        "es6-promise": "^4.2.8",
-        "form-data": "^3.0.0",
-        "graceful-fs": "^4.2.4",
-        "node-fetch": "^2.6.1",
-        "tslib": "^1.13.0",
-        "whatwg-fetch": "^3.4.0"
-    },
-    "directories": {
-        "lib": "lib"
-    },
-    "keywords": [
-        "contensis",
-        "management",
-        "api"
-    ]
+  "name": "contensis-management-api",
+  "version": "2.0.4",
+  "description": "Contensis Javascript Management API",
+  "engines": {
+    "node": ">=8"
+  },
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "scripts": {
+    "lint": "npx tslint src/**/*.ts",
+    "pretest": "rimraf coverage/*",
+    "build": "rimraf lib/* && npx tsc -p src/tsconfig-npm.json && npm run lint",
+    "test": "karma start --test-target npm",
+    "test:watch": "karma start --test-target npm --auto-watch --no-single-run",
+    "build:es5": "rimraf bundle-es5/* && npx tsc -p src",
+    "build:esnext": "rimraf bundle-es2015/* && npx tsc -p src/tsconfig-esnext.json && npm run lint",
+    "test:esnext": "karma start",
+    "all": "npm run build && npm run test && npm run build:esnext && npm run test:esnext"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contensis/contensis-management-api.git"
+  },
+  "author": "Zengenti Ltd <development@zengenti.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/contensis/contensis-management-api/issues"
+  },
+  "homepage": "https://github.com/contensis/contensis-management-api#readme",
+  "devDependencies": {
+    "@types/jasmine": "^3.5.14",
+    "@types/node": "^12.12.54",
+    "copy-webpack-plugin": "^6.4.0",
+    "istanbul-instrumenter-loader": "^3.0.1",
+    "jasmine-ajax": "^4.0.0",
+    "jasmine-core": "^3.6.0",
+    "karma": "^6.1.1",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.2",
+    "karma-jasmine": "^2.0.1",
+    "karma-jasmine-html-reporter": "^1.5.4",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-sourcemap-loader": "^0.3.8",
+    "karma-webpack": "^3.0.5",
+    "rimraf": "^2.7.1",
+    "ts-loader": "^3.5.0",
+    "tslint": "^5.20.1",
+    "typescript": "3.3.1",
+    "uglify-js": "^3.10.3",
+    "webpack": "3.12.0"
+  },
+  "dependencies": {
+    "@types/graceful-fs": "^4.1.3",
+    "contensis-core-api": "1.0.4",
+    "cross-fetch": "^3.0.6",
+    "es6-promise": "^4.2.8",
+    "form-data": "^3.0.0",
+    "graceful-fs": "^4.2.4",
+    "node-fetch": "^2.6.1",
+    "tslib": "^1.13.0",
+    "whatwg-fetch": "^3.4.0"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "keywords": [
+    "contensis",
+    "management",
+    "api"
+  ]
 }

--- a/src/models/GroupListOptions.ts
+++ b/src/models/GroupListOptions.ts
@@ -1,3 +1,6 @@
 import { UserListOptions } from './UserListOptions';
 export interface GroupListOptions extends UserListOptions {
 }
+
+export type GroupChildListOptions = Pick<GroupListOptions, Exclude<keyof GroupListOptions, 'q'>>;
+export type GroupUserListOptions = Pick<UserListOptions, Exclude<keyof UserListOptions, 'q'>>;

--- a/src/models/IGroupOperations.ts
+++ b/src/models/IGroupOperations.ts
@@ -2,6 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
+import { UserListOptions } from '.';
 
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
@@ -16,8 +17,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
 }

--- a/src/models/IGroupOperations.ts
+++ b/src/models/IGroupOperations.ts
@@ -2,7 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
-import { UserListOptions } from '.';
+import { UserListOptions, GroupUserListOptions, GroupChildListOptions } from '.';
 
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;
@@ -17,8 +17,8 @@ export interface IGroupOperations {
     hasUser(groupId: string, userId: string): Promise<boolean>;
     addChildGroup(groupId: string, childGroupId: string): Promise<void>;
     removeChildGroup(groupId: string, childGroupId: string): Promise<void>;
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>>;
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>>;
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>>;
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>>;
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>>;
 }

--- a/src/models/IGroupOperations.ts
+++ b/src/models/IGroupOperations.ts
@@ -2,7 +2,7 @@ import { Group } from './Group';
 import { PagedList } from 'contensis-core-api';
 import { GroupListOptions } from './GroupListOptions';
 import { User } from './User';
-import { UserListOptions, GroupUserListOptions, GroupChildListOptions } from '.';
+import { GroupUserListOptions, GroupChildListOptions } from '.';
 
 export interface IGroupOperations {
     getById(groupId: string): Promise<Group>;

--- a/src/security/groups/group-operations.spec.ts
+++ b/src/security/groups/group-operations.spec.ts
@@ -454,6 +454,25 @@ describe('Group Operations', () => {
             expect(users.items[1].username).toEqual(defaultUsers[1].username);
         });
 
+        it('by group id with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupId(defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+
+            expect((global.fetch as any).calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+
+            expect((global.fetch as any).calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].id}/users?order=username&pageIndex=1&pageSize=50`,
+                getDefaultFetchRequest()
+            ]);
+
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(defaultUsers[1].username);
+        });
+
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(getDefaultConfig());
             let users = await client.security.groups.getUsersByGroupName(defaultGroups[0].name);
@@ -462,6 +481,25 @@ describe('Group Operations', () => {
 
             expect((global.fetch as any).calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${defaultGroups[0].name}/users`,
+                getDefaultFetchRequest()
+            ]);
+
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].username).toEqual(defaultUsers[1].username);
+        });
+
+        it('by group name with specific options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getUsersByGroupName(defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['username']
+            });
+
+            expect((global.fetch as any).calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+
+            expect((global.fetch as any).calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].name}/users?order=username&pageIndex=1&pageSize=50`,
                 getDefaultFetchRequest()
             ]);
 
@@ -502,6 +540,25 @@ describe('Group Operations', () => {
             expect(groups.items[1].name).toEqual(defaultGroups[1].name);
         });
 
+        it('by group id with options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let groups = await client.security.groups.getChildGroupsByGroupId(defaultGroups[0].id, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+
+            expect((global.fetch as any).calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+
+            expect((global.fetch as any).calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].id}/groups?order=name&pageIndex=1&pageSize=50`,
+                getDefaultFetchRequest()
+            ]);
+
+            expect(groups).not.toBeNull();
+            expect(groups.items.length).toEqual(2);
+            expect(groups.items[1].name).toEqual(defaultGroups[1].name);
+        });
+
         it('by group name', async () => {
             let client = Zengenti.Contensis.Client.create(getDefaultConfig());
             let users = await client.security.groups.getChildGroupsByGroupName(defaultGroups[0].name);
@@ -510,6 +567,25 @@ describe('Group Operations', () => {
 
             expect((global.fetch as any).calls.mostRecent().args).toEqual([
                 `http://my-website.com/api/security/groups/${defaultGroups[0].name}/groups`,
+                getDefaultFetchRequest()
+            ]);
+
+            expect(users).not.toBeNull();
+            expect(users.items.length).toEqual(2);
+            expect(users.items[1].name).toEqual(defaultGroups[1].name);
+        });
+
+        it('by group name with options', async () => {
+            let client = Zengenti.Contensis.Client.create(getDefaultConfig());
+            let users = await client.security.groups.getChildGroupsByGroupName(defaultGroups[0].name, {
+                pageOptions: { pageIndex: 1, pageSize: 50 },
+                order: ['name']
+            });
+
+            expect((global.fetch as any).calls.first().args[0]).toEqual(getDefaultAuthenticateUrl());
+
+            expect((global.fetch as any).calls.mostRecent().args).toEqual([
+                `http://my-website.com/api/security/groups/${defaultGroups[0].name}/groups?order=name&pageIndex=1&pageSize=50`,
                 getDefaultFetchRequest()
             ]);
 

--- a/src/security/groups/group-operations.ts
+++ b/src/security/groups/group-operations.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
 import { IHttpClient, PagedList, UrlBuilder, MapperFn, ClientParams } from 'contensis-core-api';
 
 let listMappers: { [key: string]: MapperFn } = {
@@ -7,6 +7,11 @@ let listMappers: { [key: string]: MapperFn } = {
     order: (value: string[]) => (value && value.length > 0) ? value : null,
 };
 
+let userListMappers: { [key: string]: MapperFn } = {
+    pageIndex: (value: number, options: UserListOptions, params: ClientParams) => (options && options.pageOptions && options.pageOptions.pageIndex) || (params.pageIndex),
+    pageSize: (value: number, options: UserListOptions, params: ClientParams) => (options && options.pageOptions && options.pageOptions.pageSize) || (params.pageSize),
+    order: (value: string[]) => (value && value.length > 0) ? value : null,
+};
 
 export class GroupOperations implements IGroupOperations {
 
@@ -252,34 +257,34 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    getUsersByGroupId(groupId: string): Promise<PagedList<User>> {
+    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>> {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
 
-        return this.getUsersInGroup(groupId);
+        return this.getUsersInGroup(groupId, options);
     }
-    getUsersByGroupName(groupName: string): Promise<PagedList<User>> {
+    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>> {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
 
-        return this.getUsersInGroup(groupName);
+        return this.getUsersInGroup(groupName, options);
     }
 
-    getChildGroupsByGroupId(groupId: string): Promise<PagedList<Group>> {
+    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>> {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
 
-        return this.getChildGroups(groupId);
+        return this.getChildGroups(groupId, options);
     }
-    getChildGroupsByGroupName(groupName: string): Promise<PagedList<Group>> {
+    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>> {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
 
-        return this.getChildGroups(groupName);
+        return this.getChildGroups(groupName, options);
     }
 
     private getGroup(idOrName: string) {
@@ -294,10 +299,13 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    private getUsersInGroup(idOrName: string) {
-        let url = UrlBuilder.create('/api/security/groups/:idOrName/users', {})
+    private getUsersInGroup(idOrName: string, options?: UserListOptions) {
+        let url = UrlBuilder.create('/api/security/groups/:idOrName/users',
+            !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(userListMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request<PagedList<User>>(url, {
@@ -306,10 +314,13 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    private getChildGroups(idOrName: string) {
-        let url = UrlBuilder.create('/api/security/groups/:idOrName/groups', {})
+    private getChildGroups(idOrName: string, options?: GroupListOptions) {
+        let url = UrlBuilder.create('/api/security/groups/:idOrName/groups',
+            !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
+            .addOptions(options)
             .setParams(this.contensisClient.getParams())
+            .addMappers(listMappers)
             .toUrl();
         return this.contensisClient.ensureBearerToken().then(() => {
             return this.httpClient.request<PagedList<Group>>(url, {

--- a/src/security/groups/group-operations.ts
+++ b/src/security/groups/group-operations.ts
@@ -1,4 +1,4 @@
-import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions } from '../../models';
+import { ContensisClient, Group, GroupListOptions, IGroupOperations, User, UserListOptions, GroupUserListOptions, GroupChildListOptions } from '../../models';
 import { IHttpClient, PagedList, UrlBuilder, MapperFn, ClientParams } from 'contensis-core-api';
 
 let listMappers: { [key: string]: MapperFn } = {
@@ -257,14 +257,14 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    getUsersByGroupId(groupId: string, options?: UserListOptions): Promise<PagedList<User>> {
+    getUsersByGroupId(groupId: string, options?: GroupUserListOptions): Promise<PagedList<User>> {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
 
         return this.getUsersInGroup(groupId, options);
     }
-    getUsersByGroupName(groupName: string, options?: UserListOptions): Promise<PagedList<User>> {
+    getUsersByGroupName(groupName: string, options?: GroupUserListOptions): Promise<PagedList<User>> {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
@@ -272,14 +272,14 @@ export class GroupOperations implements IGroupOperations {
         return this.getUsersInGroup(groupName, options);
     }
 
-    getChildGroupsByGroupId(groupId: string, options?: GroupListOptions): Promise<PagedList<Group>> {
+    getChildGroupsByGroupId(groupId: string, options?: GroupChildListOptions): Promise<PagedList<Group>> {
         if (!groupId) {
             throw new Error('A valid group id value needs to be specified.');
         }
 
         return this.getChildGroups(groupId, options);
     }
-    getChildGroupsByGroupName(groupName: string, options?: GroupListOptions): Promise<PagedList<Group>> {
+    getChildGroupsByGroupName(groupName: string, options?: GroupChildListOptions): Promise<PagedList<Group>> {
         if (!groupName) {
             throw new Error('A valid group name value needs to be specified.');
         }
@@ -299,7 +299,7 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    private getUsersInGroup(idOrName: string, options?: UserListOptions) {
+    private getUsersInGroup(idOrName: string, options?: GroupUserListOptions) {
         let url = UrlBuilder.create('/api/security/groups/:idOrName/users',
             !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')
@@ -314,7 +314,7 @@ export class GroupOperations implements IGroupOperations {
         });
     }
 
-    private getChildGroups(idOrName: string, options?: GroupListOptions) {
+    private getChildGroups(idOrName: string, options?: GroupChildListOptions) {
         let url = UrlBuilder.create('/api/security/groups/:idOrName/groups',
             !options ? {} : { q: null, pageIndex: null, pageSize: null, order: null })
             .addOptions(idOrName, 'idOrName')


### PR DESCRIPTION
These changes allow passing through pagination/search options to the HTTP Management API.