### PR TITLE
fix: export `UniversalClient` in package root

### DIFF
--- a/bundle-es2015/index.d.ts
+++ b/bundle-es2015/index.d.ts
@@ -1,2 +1,3 @@
 export { ManagementQuery as Query, ManagementZenqlQuery as ZenqlQuery, Op, OrderBy } from 'contensis-core-api';
 export { Client } from './client/client';
+export { UniversalClient } from './client/universal_client';

--- a/bundle-es2015/index.js
+++ b/bundle-es2015/index.js
@@ -1,2 +1,3 @@
 export { ManagementQuery as Query, ManagementZenqlQuery as ZenqlQuery, Op, OrderBy } from 'contensis-core-api';
 export { Client } from './client/client';
+export { UniversalClient } from './client/universal_client';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,2 +1,3 @@
 export { ManagementQuery as Query, ManagementZenqlQuery as ZenqlQuery, Op, OrderBy } from 'contensis-core-api';
 export { Client } from './client/client';
+export { UniversalClient } from './client/universal_client';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Client = exports.OrderBy = exports.Op = exports.ZenqlQuery = exports.Query = void 0;
+exports.UniversalClient = exports.Client = exports.OrderBy = exports.Op = exports.ZenqlQuery = exports.Query = void 0;
 var contensis_core_api_1 = require("contensis-core-api");
 Object.defineProperty(exports, "Query", { enumerable: true, get: function () { return contensis_core_api_1.ManagementQuery; } });
 Object.defineProperty(exports, "ZenqlQuery", { enumerable: true, get: function () { return contensis_core_api_1.ManagementZenqlQuery; } });
@@ -8,3 +8,5 @@ Object.defineProperty(exports, "Op", { enumerable: true, get: function () { retu
 Object.defineProperty(exports, "OrderBy", { enumerable: true, get: function () { return contensis_core_api_1.OrderBy; } });
 var client_1 = require("./client/client");
 Object.defineProperty(exports, "Client", { enumerable: true, get: function () { return client_1.Client; } });
+var universal_client_1 = require("./client/universal_client");
+Object.defineProperty(exports, "UniversalClient", { enumerable: true, get: function () { return universal_client_1.UniversalClient; } });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export {  ManagementQuery as Query, ManagementZenqlQuery as ZenqlQuery, Op, OrderBy } from 'contensis-core-api';
+export { ManagementQuery as Query, ManagementZenqlQuery as ZenqlQuery, Op, OrderBy } from 'contensis-core-api';
 export { Client } from './client/client';
+export { UniversalClient } from './client/universal_client';


### PR DESCRIPTION
When building bundles for browser clients using the existing (unofficial) export path `contensis-management-api/lib/client/universal_client` we are getting errors regarding missing builtins for NodeJS libraries and the resulting bundle looks like it contains everything from all node_modules.

Adding and using the export at the root of the package (referenced by `main` field in `package.json`) fixes this problem and browser bundles build normally (without adding NodeJS dependencies)